### PR TITLE
IMS: Fix ImsService crash due to default phones not created.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -3,7 +3,7 @@ LOCAL_PATH:= $(call my-dir)
 # Build the Telecom service.
 include $(CLEAR_VARS)
 
-LOCAL_JAVA_LIBRARIES := telephony-common
+LOCAL_JAVA_LIBRARIES := telephony-common ims-common
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 LOCAL_SRC_FILES += \

--- a/src/com/android/server/telecom/ui/ViceNotificationImpl.java
+++ b/src/com/android/server/telecom/ui/ViceNotificationImpl.java
@@ -32,9 +32,11 @@ package com.android.server.telecom.ui;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -55,6 +57,7 @@ import android.telecom.VideoProfile;
 import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 
+import com.android.ims.ImsManager;
 import com.android.internal.telephony.TelephonyProperties;
 import com.android.server.telecom.Call;
 import com.android.server.telecom.CallState;
@@ -114,6 +117,8 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
 
     // HashMap that holds Dialog Number & Notification Id used to display on the statusbar
     private Map<String,Integer> mNotification = new HashMap<String,Integer>();
+    
+    private ImsIntentReceiver mImsIntentReceiver = null;
 
     private static final String IMS_SERVICE_PKG_NAME = "org.codeaurora.ims";
 
@@ -122,7 +127,10 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
         mNotificationManager =
                 (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         Log.i(this,"ViceNotificationImpl");
-        bindImsService();
+        if (!bindImsService()) {
+            //Register for IMS ready intent to re try bind            
+            registerImsReceiver();            
+        }            
     }
 
     private class MyHandler extends Handler {
@@ -153,6 +161,18 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
         }
     }
 
+    private class ImsIntentReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            Log.i("ViceNotificationImpl", "mImsIntentReceiver: action " + intent.getAction());
+            if (ImsManager.ACTION_IMS_SERVICE_UP.equals(intent.getAction())) {
+                if (bindImsService()) {
+                    unregisterImsReceiver();                    
+                }
+            }
+        }
+    }                    
+
     // Clear the existing notifications on statusbar and
     // Hashmap whenever new Vice Notification is received
     private void resetBeforeProcess() {
@@ -168,6 +188,7 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
 
         /* Below API gets invoked when connection to ImsService is established */
         public void onServiceConnected(ComponentName className, IBinder service) {
+            Log.i("ViceNotificationImpl", "onServiceConnected");            
             /* Retrieve the IQtiImsInterface */
             mQtiImsInterface = IQtiImsInterface.Stub.asInterface(service);
 
@@ -184,6 +205,7 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
 
         /* Below API gets invoked when connection to ImsService is disconnected */
         public void onServiceDisconnected(ComponentName className) {
+            Log.i("ViceNotificationImpl", "onServiceDisconnected");            
         }
     };
 
@@ -228,11 +250,15 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
      * Returns true if bound sucessfully, false otherwise.
      */
     public boolean bindImsService() {
+        if (!ImsManager.getInstance(mContext, 0).isServiceAvailable()) {
+            Log.d(this, "bindImsService: IMS service is not available!");
+            return false;
+        }            
         Intent intent = new Intent(IQtiImsInterface.class.getName());
         intent.setPackage(IMS_SERVICE_PKG_NAME);
         mImsServiceBound = mContext.bindService(intent,
                                    mConnection,
-                                   Context.BIND_AUTO_CREATE);
+                                   0);
         Log.d(this, "Getting IQtiImsInterface : " + (mImsServiceBound?"yes":"failed"));
         return mImsServiceBound;
     }
@@ -527,4 +553,18 @@ public class ViceNotificationImpl extends CallsManagerListenerBase {
             mHandler.sendEmptyMessage(MyHandler.MESSAGE_CALL_ENDED);
         }
     }
+    
+    private void registerImsReceiver() {    
+        mImsIntentReceiver = new ImsIntentReceiver();    
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(ImsManager.ACTION_IMS_SERVICE_UP);
+        mContext.registerReceiver(mImsIntentReceiver, filter);        
+    }
+    
+    private void unregisterImsReceiver() {
+        if (mImsIntentReceiver != null) {        
+            mContext.unregisterReceiver(mImsIntentReceiver);
+            mImsIntentReceiver = null;
+        }
+    }        
 }

--- a/tests/Android.mk
+++ b/tests/Android.mk
@@ -37,7 +37,8 @@ LOCAL_RESOURCE_DIR := \
 
 LOCAL_JAVA_LIBRARIES := \
         android.test.runner \
-        telephony-common
+        telephony-common \
+        ims-common        
 
 LOCAL_AAPT_FLAGS := \
     --auto-add-overlay \


### PR DESCRIPTION
If IMS service is bound from telecom service before phone app
is created, it can lead to exception when accessing phone objects.
So check for IMS service available before binding and remove
AUTO_CREATE flag while binding to IMS service.
Also register for IMS_UP intent to retry bind when IMS service
becomes ready.
